### PR TITLE
feat: add custom reply hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ fastify.register(require('fastify-circuit-breaker'), {
   threshold: 3, // default 5
   timeout: 5000, // default 10000
   resetTimeout: 5000 // default 10000
-  onCircuitOpen: (req, reply) => {
+  onCircuitOpen: async (req, reply) => {
     reply.statusCode = 500
     throw new Error('a custom error')
   },
-  onTimeout: (req, reply) => {
+  onTimeout: async (req, reply) => {
     reply.statusCode = 504
     return 'timed out'
   }

--- a/README.md
+++ b/README.md
@@ -55,11 +55,21 @@ fastify.register(require('fastify-circuit-breaker'), {
   threshold: 3, // default 5
   timeout: 5000, // default 10000
   resetTimeout: 5000 // default 10000
+  onCircuitOpen: (req, reply) => {
+    reply.statusCode = 500
+    throw new Error('a custom error')
+  },
+  onTimeout: (req, reply) => {
+    reply.statusCode = 504
+    return 'timed out'
+  }
 })
 ```
 - `threshold`: is the maximum numbers of failures you accept to have before opening the circuit.
 - `timeout:` is the maximum number of milliseconds you can wait before return a `TimeoutError`.
 - `resetTimeout`: number of milliseconds before the circuit will move from `open` to `half-open`
+- `onCircuitOpen`: function that gets called when the circuit is `open` due to errors. It can modify the reply and return a `string` | `Buffer` | `Stream` payload.  If an `Error` is thrown it will be routed to your error handler. 
+- `onTimeout`: function that gets called when the circuit is `open` due to timeouts.  It can modify the reply and return a `string` | `Buffer` | `Stream` | `Error` payload.  If an `Error` is thrown it will be routed to your error handler.  
 
 Otherwise you can customize every single route by passing the same options to the `circuitBreaker` utility:
 ```js
@@ -72,7 +82,7 @@ fastify.circuitBreaker({
 If you pass the options directly to the utility, it will take precedence over the global configuration.
 
 ### Customize error messages
-If needed you can change the default error message for the *circui open error* and the *timeout error*:
+If needed you can change the default error message for the *circuit open error* and the *timeout error*:
 ```js
 fastify.register(require('fastify-circuit-breaker'), {
   timeoutErrorMessage: 'Ronf...', // default 'Timeout'

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fastify.register(require('fastify-circuit-breaker'), {
 - `timeout:` is the maximum number of milliseconds you can wait before return a `TimeoutError`.
 - `resetTimeout`: number of milliseconds before the circuit will move from `open` to `half-open`
 - `onCircuitOpen`: function that gets called when the circuit is `open` due to errors. It can modify the reply and return a `string` | `Buffer` | `Stream` payload.  If an `Error` is thrown it will be routed to your error handler. 
-- `onTimeout`: function that gets called when the circuit is `open` due to timeouts.  It can modify the reply and return a `string` | `Buffer` | `Stream` | `Error` payload.  If an `Error` is thrown it will be routed to your error handler.  
+- `onTimeout`: async function that gets called when the circuit is `open` due to timeouts.  It can modify the reply and return a `string` | `Buffer` | `Stream` | `Error` payload.  If an `Error` is thrown it will be routed to your error handler.  
 
 Otherwise you can customize every single route by passing the same options to the `circuitBreaker` utility:
 ```js

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fastify.register(require('fastify-circuit-breaker'), {
 - `threshold`: is the maximum numbers of failures you accept to have before opening the circuit.
 - `timeout:` is the maximum number of milliseconds you can wait before return a `TimeoutError`.
 - `resetTimeout`: number of milliseconds before the circuit will move from `open` to `half-open`
-- `onCircuitOpen`: function that gets called when the circuit is `open` due to errors. It can modify the reply and return a `string` | `Buffer` | `Stream` payload.  If an `Error` is thrown it will be routed to your error handler. 
+- `onCircuitOpen`: async function that gets called when the circuit is `open` due to errors. It can modify the reply and return a `string` | `Buffer` | `Stream` payload.  If an `Error` is thrown it will be routed to your error handler. 
 - `onTimeout`: async function that gets called when the circuit is `open` due to timeouts.  It can modify the reply and return a `string` | `Buffer` | `Stream` | `Error` payload.  If an `Error` is thrown it will be routed to your error handler.  
 
 Otherwise you can customize every single route by passing the same options to the `circuitBreaker` utility:


### PR DESCRIPTION
I was looking to customize the reply status code and came across the discussion here https://github.com/fastify/fastify-circuit-breaker/issues/15.  This implementation allows you to customize the reply for timeouts and errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x ] run `npm run test` and `npm run benchmark`
- [x ] tests and/or benchmarks are included
- [x ] documentation is changed or added
- [ x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
