### PR TITLE
added a missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can pass the following options during the plugin registration, in this way t
 fastify.register(require('fastify-circuit-breaker'), {
   threshold: 3, // default 5
   timeout: 5000, // default 10000
-  resetTimeout: 5000 // default 10000
+  resetTimeout: 5000, // default 10000
   onCircuitOpen: async (req, reply) => {
     reply.statusCode = 500
     throw new Error('a custom error')


### PR DESCRIPTION
fixed a typo in README. the options code example 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
