### PR TITLE
Minor refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,4 @@ jobs:
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
     with:
       license-check: true
+      lint: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.taprc
+++ b/.taprc
@@ -1,1 +1,2 @@
 check-coverage: false
+jobs: 4

--- a/examples/example.js
+++ b/examples/example.js
@@ -2,7 +2,7 @@
 
 const fastify = require('fastify')()
 
-fastify.register(require('./index'), {
+fastify.register(require('..'), {
   threshold: 3,
   timeout: 5000,
   resetTimeout: 5000

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const inherits = require('util').inherits
 const fp = require('fastify-plugin')
 const lru = require('tiny-lru')
+const createError = require('@fastify/error')
 
 const OPEN = 'open'
 const HALFOPEN = 'half-open'
@@ -131,25 +131,17 @@ function circuitBreakerPlugin (fastify, opts, next) {
     }, route.resetTimeout)
   }
 
-  function TimeoutError (message) {
-    Error.call(this)
-    Error.captureStackTrace(this, TimeoutError)
-    this.name = 'TimeoutError'
-    this.message = timeoutErrorMessage
-    this.statusCode = 503
-  }
+  const TimeoutError = createError(
+    'FST_ERR_CIRCUIT_BREAKER_TIMEOUT',
+    timeoutErrorMessage,
+    503
+  )
 
-  inherits(TimeoutError, Error)
-
-  function CircuitOpenError (message) {
-    Error.call(this)
-    Error.captureStackTrace(this, CircuitOpenError)
-    this.name = 'CircuitOpenError'
-    this.message = circuitOpenErrorMessage
-    this.statusCode = 503
-  }
-
-  inherits(CircuitOpenError, Error)
+  const CircuitOpenError = createError(
+    'FST_ERR_CIRCUIT_BREAKER_OPEN',
+    circuitOpenErrorMessage,
+    503
+  )
 
   function getTime () {
     const ts = process.hrtime()

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const fp = require('fastify-plugin')
 const lru = require('tiny-lru')
 const createError = require('@fastify/error')
 
-const OPEN = 'open'
-const HALFOPEN = 'half-open'
-const CLOSE = 'close'
+const OPEN = Symbol('open')
+const HALFOPEN = Symbol('half-open')
+const CLOSE = Symbol('close')
 
 function circuitBreakerPlugin (fastify, opts, next) {
   opts = opts || {}

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "3.0.0",
   "description": "A low overhead circuit breaker for your routes",
   "main": "index.js",
-  "types": "index.d.ts",
+  "types": "types/index.d.ts",
   "type": "commonjs",
   "scripts": {
-    "test": "standard && tap -j4 test.js && npm run typescript",
-    "typescript": "tsd"
+    "lint": "standard",
+    "test": "npm run test:unit && npm run test:typescript",
+    "test:unit": "tap -j4 test.js",
+    "test:typescript": "tsd"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap -j4 test.js",
+    "test:unit": "tap",
     "test:typescript": "tsd"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "tsd": "^0.22.0"
   },
   "dependencies": {
+    "@fastify/error": "^3.0.0",
     "fastify-plugin": "^4.0.0",
     "tiny-lru": "^8.0.1"
   },

--- a/test.js
+++ b/test.js
@@ -62,7 +62,8 @@ test('Should respond with a 503 once the threshold has been reached', t => {
     t.same({
       error: 'Service Unavailable',
       message: 'Circuit open',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
     }, JSON.parse(res.payload))
   })
 })
@@ -95,7 +96,8 @@ test('Should respond with a 503 once the threshold has been reached (timeout)', 
     t.same({
       error: 'Service Unavailable',
       message: 'Timeout',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_TIMEOUT'
     }, JSON.parse(res.payload))
   })
 
@@ -105,7 +107,8 @@ test('Should respond with a 503 once the threshold has been reached (timeout)', 
     t.same({
       error: 'Service Unavailable',
       message: 'Timeout',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_TIMEOUT'
     }, JSON.parse(res.payload))
   })
 
@@ -115,7 +118,8 @@ test('Should respond with a 503 once the threshold has been reached (timeout)', 
     t.same({
       error: 'Service Unavailable',
       message: 'Timeout',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_TIMEOUT'
     }, JSON.parse(res.payload))
   })
 
@@ -126,7 +130,8 @@ test('Should respond with a 503 once the threshold has been reached (timeout)', 
       t.same({
         error: 'Service Unavailable',
         message: 'Circuit open',
-        statusCode: 503
+        statusCode: 503,
+        code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
       }, JSON.parse(res.payload))
     })
   }, 200)
@@ -170,7 +175,8 @@ test('Should return 503 until the circuit is open', t => {
     t.same({
       error: 'Service Unavailable',
       message: 'Circuit open',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
     }, JSON.parse(res.payload))
   })
 
@@ -221,7 +227,8 @@ test('If the staus is half-open and there is an error the state should be open a
     t.same({
       error: 'Service Unavailable',
       message: 'Circuit open',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
     }, JSON.parse(res.payload))
   })
 
@@ -242,7 +249,8 @@ test('If the staus is half-open and there is an error the state should be open a
       t.same({
         error: 'Service Unavailable',
         message: 'Circuit open',
-        statusCode: 503
+        statusCode: 503,
+        code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
       }, JSON.parse(res.payload))
     })
   }, 1000)
@@ -275,7 +283,8 @@ test('Should customize circuit open error message', t => {
     t.same({
       error: 'Service Unavailable',
       message: 'Oh gosh!',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
     }, JSON.parse(res.payload))
   })
 })
@@ -308,7 +317,8 @@ test('Should customize timeout error message', t => {
     t.same({
       error: 'Service Unavailable',
       message: 'Oh gosh!',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_TIMEOUT'
     }, JSON.parse(res.payload))
   })
 })
@@ -344,7 +354,8 @@ test('One route should not interfere with others', t => {
     t.same({
       error: 'Service Unavailable',
       message: 'Circuit open',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
     }, JSON.parse(res.payload))
   })
 
@@ -419,7 +430,8 @@ test('Should handle also errors with statusCode property', t => {
     t.same({
       error: 'Service Unavailable',
       message: 'Circuit open',
-      statusCode: 503
+      statusCode: 503,
+      code: 'FST_ERR_CIRCUIT_BREAKER_OPEN'
     }, JSON.parse(res.payload))
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('fastify')
-const circuitBreaker = require('./index')
+const circuitBreaker = require('..')
 
 const opts = {
   schema: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import {
-  FastifyPlugin,
+  FastifyPluginCallback,
   FastifyRequest,
   FastifyReply,
   HookHandlerDoneFunction,
@@ -40,6 +40,6 @@ export type FastifyCircuitBreakerOptions = {
   resetTimeout?: number;
 };
 
-export const fastifyCircuitBreaker: FastifyPlugin<FastifyCircuitBreakerOptions>;
+export const fastifyCircuitBreaker: FastifyPluginCallback<FastifyCircuitBreakerOptions>;
 
 export default fastifyCircuitBreaker;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import fastify from "fastify";
-import FastifyCircuitBreaker, { FastifyCircuitBreakerOptions } from ".";
+import FastifyCircuitBreaker, { FastifyCircuitBreakerOptions } from "..";
 
 const app = fastify();
 


### PR DESCRIPTION
- use FastifyPluginCallback instead of deprecated FastifyPlugin type
- use @fastify/error for Error Classes
- use Symbols instead of strings for the three states of the circuit breaker
- activate linting in workflow
- disabled package-lock generation
- moved tests to test folder
- set tap configuration only in .taprc
- move example into examples folder

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
