### PR TITLE
build(deps): replace tiny-lru with toad-cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const lru = require('tiny-lru').lru
+const { LruObject } = require('toad-cache')
 const createError = require('@fastify/error')
 
 const OPEN = Symbol('open')
@@ -17,7 +17,7 @@ function fastifyCircuitBreaker (fastify, opts, next) {
   const circuitOpenErrorMessage = opts.circuitOpenErrorMessage || 'Circuit open'
   const onCircuitOpen = opts.onCircuitOpen
   const onTimeout = opts.onTimeout
-  const cache = lru(opts.cache || 500)
+  const cache = new LruObject(opts.cache || 500)
 
   let routeId = 0
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const { LruObject } = require('toad-cache')
+const { FifoObject } = require('toad-cache')
 const createError = require('@fastify/error')
 
 const OPEN = Symbol('open')
@@ -17,7 +17,7 @@ function fastifyCircuitBreaker (fastify, opts, next) {
   const circuitOpenErrorMessage = opts.circuitOpenErrorMessage || 'Circuit open'
   const onCircuitOpen = opts.onCircuitOpen
   const onTimeout = opts.onTimeout
-  const cache = new LruObject(opts.cache || 500)
+  const cache = new FifoObject(opts.cache || 500)
 
   let routeId = 0
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fastify/error": "^3.0.0",
     "fastify-plugin": "^4.0.0",
-    "tiny-lru": "^11.0.0"
+    "toad-cache": "^3.7.0"
   },
   "bugs": {
     "url": "https://github.com/fastify/fastify-circuit-breaker/issues"


### PR DESCRIPTION
This brings fastify-reply-from in line with fastify, fastify-cigtm and fastify-rate-limit, by switching to toad-cache, which is faster than tiny-lru.

See [benchmark](https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/cache-get-inmemory/_results/results.md) results.

Ref: https://github.com/fastify/fastify-reply-from/pull/346

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
